### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,15 @@ Installation
 ------------
 
 The build-system is now integrated in the `clickable` Version 3.2.0.
-* Install [Golang] (https://golang.org/doc/install
+* Install [Golang] (https://golang.org/doc/install)
 * Add gopath to ~/.bashrc https://github.com/golang/go/wiki/SettingGOPATH
-* Check out this git `go get -d https://github.com/nanu-c/textsecure-qml`
-* `cd $GOPATH/src/github.com/nanu-c/textsecure-qml`
 * install dependencies `sudo apt install mercurial bzr`
-* Get dependencies `go get -d ./...`
+* Check out this git `go get -d github.com/nanu-c/textsecure-qml`
+* `cd $(go env GOPATH)/src/github.com/nanu-c/textsecure-qml`
 * Get [clickable](https://github.com/bhdouglass/clickable#install)
 * Build the modified docker container with `cd docker&& docker build -t nanuc/ut-textsecure-sdk:16.04 .`
 * Back to main dir, then
-* Run clickable `clickable`, this also transfers the click package to the Ubuntu Touch Phone
+* Run `clickable`, this also transfers the click package to the Ubuntu Touch Phone
 * Run `clickable launch logs` to start signal and watch the log
 
 Contributing


### PR DESCRIPTION
Fixes:

*  a markdown syntax error (unclosed link bracket)
* `go get -d https://github…` yields an error. Removed `https://` to make it work.
* duplicate "clickable `clickable`", because that's most likely a typo

Updates according to my observations during installation:

There's no need to get dependencies using `go get - ./...` if you first install mercurial and bzr. That's why I changed the instruction order and removed `go get -d ./...`.